### PR TITLE
implement token_stat group by date

### DIFF
--- a/includes/common.py
+++ b/includes/common.py
@@ -88,6 +88,16 @@ def log_analyzer_stats(analyzer, treatment_day_start, treatment_day_end, start_t
         )
 
 
+def truncate_table_for_dates(table_name, period_dates, date_column_name="request_date"):
+    conn = psycopg2.connect(get_db_connection_string())
+    cur = conn.cursor()
+    cur.execute("DELETE from stat_compiled.{0} where {1} >= ('{2}' :: date) and {1} < ('{3}' :: date) + interval '1 day'".format(
+        table_name, date_column_name, period_dates[0], period_dates[1]
+    ))
+    cur.close()
+    conn.commit()
+    conn.close()
+
 def insert_data_into_db(table_name, columns, rows):
     conn = psycopg2.connect(get_db_connection_string())
     cur = conn.cursor()
@@ -98,6 +108,7 @@ def insert_data_into_db(table_name, columns, rows):
         table_name, columns_as_string, records_list_template
     )
     # print(insertString)
+    # print(rows)
     cur.execute(insertString, rows)
     cur.close()
     conn.commit()

--- a/token_stat.py
+++ b/token_stat.py
@@ -1,0 +1,27 @@
+import sys, os
+sys.path.append(os.path.abspath("includes"))
+from time import time
+from includes import common
+from pyspark.sql.functions import to_date
+
+start = time()
+
+(source_root, treatment_day_start, treatment_day_end) = common.get_period_from_input()
+spark = common.start_spark_session(__file__)
+file_list = common.get_file_list(source_root, treatment_day_start, treatment_day_end)
+
+df = common.get_sql_data_frame(spark, file_list)
+
+dfProcessed = df.withColumn('request_date_ts', df.request_date.cast('timestamp'))
+tokenStats = dfProcessed.groupBy(to_date('request_date_ts').alias('request_date_trunc'), 'token').count()
+tokenStats = tokenStats.collect()
+
+# tokenRow attributes can be accessed by .token, .request_date_trunc but not .count which returns count method of tuple
+tokenStats = [(tokenRow['token'], tokenRow['request_date_trunc'], tokenRow['count']) for tokenRow in tokenStats]
+
+if len(tokenStats) != 0:
+    common.truncate_table_for_dates("token_stats", (treatment_day_start, treatment_day_end))
+    common.insert_data_into_db("token_stats", ["token", "request_date", "nb_req"], tokenStats)
+
+common.terminate(spark.sparkContext)
+common.log_analyzer_stats("CanalTP\StatCompiler\Updater\TokenStatsUpdater", treatment_day_start, treatment_day_end, start)

--- a/token_stat.py
+++ b/token_stat.py
@@ -20,8 +20,8 @@ tokenStats = tokenStats.collect()
 tokenStats = [(tokenRow['token'], tokenRow['request_date_trunc'], tokenRow['count']) for tokenRow in tokenStats]
 
 if len(tokenStats) != 0:
-    common.truncate_table_for_dates("token_stats", (treatment_day_start, treatment_day_end))
-    common.insert_data_into_db("token_stats", ["token", "request_date", "nb_req"], tokenStats)
+    conn = common.truncate_table_for_dates("token_stats", (treatment_day_start, treatment_day_end))
+    common.insert_data_into_db("token_stats", ["token", "request_date", "nb_req"], tokenStats, conn)
 
 common.terminate(spark.sparkContext)
 common.log_analyzer_stats("CanalTP\StatCompiler\Updater\TokenStatsUpdater", treatment_day_start, treatment_day_end, start)


### PR DESCRIPTION
implement token_stat group by date

to test : 

```
time /path/to/spark/bin/spark-submit --driver-java-options '-Duser.timezone=UTC' --master local[3] token_stat.py /path/to/jenkins/data 2017-01-17 2017-01-17
```
runtime : 3m16


Original request :
https://github.com/CanalTP/stat-compiler/blob/c30c94a597ac30a1b3714c563e8edc12c8d8ae80/src/CanalTP/StatCompiler/Updater/TokenStatsUpdater.php