### PR TITLE
Error stats

### DIFF
--- a/analyzers/error_stat.py
+++ b/analyzers/error_stat.py
@@ -1,0 +1,37 @@
+from time import time
+from includes import common
+from pyspark.sql.functions import to_date, when, from_unixtime
+from analyzer import Analyzer
+
+class AnalyzeError(Analyzer):
+    def collect_data_from_df(self, df):
+        return df.select(
+                when(df['coverages'][0]['region_id'].isNull(), '').otherwise(df['coverages'][0]['region_id']).alias('region_id'),
+                df['api'],
+                df['request_date'],
+                df['user_id'],
+                df['application_name'],
+                df['error']['id'].alias('err_id'),
+                when(df['user_name'].like('%canaltp%'), 1).otherwise(0).alias('is_internal_call'),
+            ) \
+            .where(df['error'].isNotNull()) \
+            .groupBy('region_id', 'api', 'request_date', 'user_id', 'application_name', 'err_id', 'is_internal_call') \
+            .count() \
+            .collect();
+
+    def get_data(self):
+        files = self.get_files_to_analyze()
+        df = self.spark_context.read.json(files)
+        return self.collect_data_from_df(df)
+
+    def truncate_and_insert(self, data):
+        if len(data):
+            self.database.delete_by_date("error_stats", self.start_date, self.end_date)
+            query = "INSERT INTO stat_compiled.error_stats (region_id, api, request_date, user_id, application_name, err_id, user_name, nb_req) VALUES "
+            self.database.execute(query, data)
+
+    def launch(self):
+        error_stats = self.get_data()
+        print(error_stats)
+        #self.truncate_and_insert(error_stats)
+

--- a/analyzers/error_stat.py
+++ b/analyzers/error_stat.py
@@ -1,23 +1,22 @@
-from time import time
-from includes import common
 from pyspark.sql.functions import when, from_unixtime
 from analyzer import Analyzer
+
 
 class AnalyzeError(Analyzer):
     def collect_data_from_df(self, df):
         return df.select(
-                when(df['coverages'][0]['region_id'].isNull(), '').otherwise(df['coverages'][0]['region_id']).alias('region_id'),
-                df['api'],
-                from_unixtime(df['request_date'], 'yyyy-MM-dd').alias('request_date'),
-                df['user_id'],
-                df['application_name'],
-                df['error']['id'].alias('err_id'),
-                when(df['user_name'].like('%canaltp%'), 1).otherwise(0).alias('is_internal_call'),
-            ) \
-            .where(df['error'].isNotNull()) \
-            .groupBy('region_id', 'api', 'request_date', 'user_id', 'application_name', 'err_id', 'is_internal_call') \
-            .count() \
-            .collect();
+            when(df['coverages'][0]['region_id'].isNull(), '').otherwise(df['coverages'][0]['region_id']).
+            alias('region_id'),
+            df['api'],
+            from_unixtime(df['request_date'], 'yyyy-MM-dd').alias('request_date'),
+            df['user_id'],
+            df['application_name'],
+            df['error']['id'].alias('err_id'),
+            when(df['user_name'].like('%canaltp%'), 1).otherwise(0).alias('is_internal_call'),
+            ).where(df['error'].isNotNull())\
+            .groupBy('region_id', 'api', 'request_date', 'user_id', 'application_name', 'err_id', 'is_internal_call')\
+            .count()\
+            .collect()
 
     def get_data(self):
         files = self.get_files_to_analyze()
@@ -26,14 +25,15 @@ class AnalyzeError(Analyzer):
 
     def truncate_and_insert(self, data):
         if len(data):
-            values_to_insert = []
-            for row in data:
-                values_to_insert.append(row)
             self.database.delete_by_date("error_stats", self.start_date, self.end_date)
-            columns = ('region_id', 'api', 'request_date', 'user_id', 'app_name', 'err_id', 'is_internal_call', 'nb_req')
-            self.database.insert("error_stats", columns, values_to_insert)
+            columns = ('region_id', 'api', 'request_date', 'user_id', 'app_name', 'err_id',
+                       'is_internal_call', 'nb_req')
+            self.database.insert("error_stats", columns, data)
 
     def launch(self):
         error_stats = self.get_data()
         self.truncate_and_insert(error_stats)
 
+    @property
+    def analyzer_name(self):
+        return "ErrorStatsUpdater"

--- a/includes/database.py
+++ b/includes/database.py
@@ -49,24 +49,9 @@ class Database(object):
         self.cursor.execute(query)
         return [tuple(values) for values in self.cursor.fetchall()]
 
-    def insert(self, table_name, columns, rows):
-        columns_as_string = ", ".join(columns)
-        records_list_template = ','.join(['%s'] * len(rows))
-        insert_string = "INSERT INTO stat_compiled.{0} ({1}) VALUES {2}".format(
-            table_name, columns_as_string, records_list_template
-        )
-
-        try:
-            self.cursor.execute(insert_string, rows)
-            self.connection.commit()
-        except psycopg2.Error as e:
-            self.connection.rollback()
-            print("""
-                ERROR: Unable to insert into table %s (%s) rows:
-                %s
-                Exception:
-                %s
-            """ % (table_name, columns_as_string, rows, e))
+    def insert(self, table_name, columns, data):
+        insert_string = self.format_insert_query(table_name, columns, data)
+        self.execute(insert_string, data)
 
     def commit(self):
         self.connection.commit()

--- a/includes/database.py
+++ b/includes/database.py
@@ -49,6 +49,25 @@ class Database(object):
         self.cursor.execute(query)
         return [tuple(values) for values in self.cursor.fetchall()]
 
+    def insert(self, table_name, columns, rows):
+        columns_as_string = ", ".join(columns)
+        records_list_template = ','.join(['%s'] * len(rows))
+        insert_string = "INSERT INTO stat_compiled.{0} ({1}) VALUES {2}".format(
+            table_name, columns_as_string, records_list_template
+        )
+
+        try:
+            self.cursor.execute(insert_string, rows)
+            self.connection.commit()
+        except psycopg2.Error as e:
+            self.connection.rollback()
+            print("""
+                ERROR: Unable to insert into table %s (%s) rows:
+                %s
+                Exception:
+                %s
+            """ % (table_name, columns_as_string, rows, e))
+
     def commit(self):
         self.connection.commit()
 

--- a/includes/utils.py
+++ b/includes/utils.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
-from analyzers import token_stat, users_sql, requests_calls
+from itertools import chain, islice
+from analyzers import token_stat, users_sql, error_stat
 
 
 def analyzer_value(value):
@@ -8,6 +9,7 @@ def analyzer_value(value):
         "token_stat": token_stat.AnalyzeToken,
         "users_sql": users_sql.AnalyseUsersSql,
         "requests_calls": requests_calls.AnalyzeRequest
+		"error_stat": error_stat.AnalyzeError
     }
     lower_value = value.lower()
     if lower_value not in analyzers:

--- a/includes/utils.py
+++ b/includes/utils.py
@@ -1,15 +1,14 @@
 import os
 from datetime import datetime
-from itertools import chain, islice
-from analyzers import token_stat, users_sql, error_stat
+from analyzers import token_stat, users_sql, error_stat, requests_calls
 
 
 def analyzer_value(value):
     analyzers = {
         "token_stat": token_stat.AnalyzeToken,
         "users_sql": users_sql.AnalyseUsersSql,
-        "requests_calls": requests_calls.AnalyzeRequest
-		"error_stat": error_stat.AnalyzeError
+        "requests_calls": requests_calls.AnalyzeRequest,
+        "error_stat": error_stat.AnalyzeError
     }
     lower_value = value.lower()
     if lower_value not in analyzers:

--- a/tests/error_stat_test.py
+++ b/tests/error_stat_test.py
@@ -1,9 +1,7 @@
 import pytest
 from datetime import date
 from analyzers.error_stat import AnalyzeError
-from pyspark.sql import Row
 import os
-import pprint
 
 pytestmark = pytest.mark.usefixtures("spark")
 
@@ -21,21 +19,21 @@ def test_error_stat(spark):
     # each record have a field that change to test the groupBy clause (ie: we should only group if
     # region_id, api, request_date,  user_id, application_name, err_id and is_internal_call are equals)
     expected_results = [ \
-            {"region_id": u"fr-foo", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            {"region_id": u"fr-foo", "api": u"v1.some_api", "request_date": u"2017-01-17", "user_id": 42, \
             "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.another_api", "request_date": 148461120, "user_id": 42, \
+            {"region_id": u"fr-idf", "api": u"v1.another_api", "request_date": u"2017-01-17", "user_id": 42, \
             "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 138461120, "user_id": 42, \
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": u"2013-11-16", "user_id": 42, \
             "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 43, \
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": u"2017-01-17", "user_id": 43, \
             "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": u"2017-01-17", "user_id": 42, \
             "application_name": u"another_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": u"2017-01-17", "user_id": 42, \
             "application_name": u"my_app", "err_id": u"another_error_id", "is_internal_call": 0, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": u"2017-01-17", "user_id": 42, \
             "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 1, "count": 1},
-            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": u"2017-01-17", "user_id": 42, \
             "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 3},
     ]
     results_to_compare = [];
@@ -43,6 +41,7 @@ def test_error_stat(spark):
         results_to_compare.append(result.asDict());
 
     assert len(expected_results) == len(results_to_compare)
+
     for expected_result in expected_results:
         assert expected_result in results_to_compare
 

--- a/tests/error_stat_test.py
+++ b/tests/error_stat_test.py
@@ -1,0 +1,48 @@
+import pytest
+from datetime import date
+from analyzers.error_stat import AnalyzeError
+from pyspark.sql import Row
+import os
+import pprint
+
+pytestmark = pytest.mark.usefixtures("spark")
+
+def test_error_stat(spark):
+    path = os.getcwd() + "/tests/fixtures/error_stat"
+    start_date = date(2017, 1, 15)
+    end_date = date(2017, 1, 15)
+
+    analyzer = AnalyzeError(storage_path=path,
+                             start_date=start_date,
+                             end_date=end_date,
+                             spark_context=spark, database=None)
+
+    results = analyzer.get_data()
+    # each record have a field that change to test the groupBy clause (ie: we should only group if
+    # region_id, api, request_date,  user_id, application_name, err_id and is_internal_call are equals)
+    expected_results = [ \
+            {"region_id": u"fr-foo", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.another_api", "request_date": 148461120, "user_id": 42, \
+            "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 138461120, "user_id": 42, \
+            "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 43, \
+            "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            "application_name": u"another_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            "application_name": u"my_app", "err_id": u"another_error_id", "is_internal_call": 0, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 1, "count": 1},
+            {"region_id": u"fr-idf", "api": u"v1.some_api", "request_date": 148461120, "user_id": 42, \
+            "application_name": u"my_app", "err_id": u"some_error_id", "is_internal_call": 0, "count": 3},
+    ]
+    results_to_compare = [];
+    for result in results:
+        results_to_compare.append(result.asDict());
+
+    assert len(expected_results) == len(results_to_compare)
+    for expected_result in expected_results:
+        assert expected_result in results_to_compare
+

--- a/tests/error_stat_test.py
+++ b/tests/error_stat_test.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import date
+from datetime import date, datetime
 from analyzers.error_stat import AnalyzeError
 import os
 
@@ -13,7 +13,9 @@ def test_error_stat(spark):
     analyzer = AnalyzeError(storage_path=path,
                              start_date=start_date,
                              end_date=end_date,
-                             spark_context=spark, database=None)
+                             spark_context=spark,
+                             database=None,
+                             current_datetime=datetime(2017, 2, 15, 15, 10))
 
     results = analyzer.get_data()
     # each record have a field that change to test the groupBy clause (ie: we should only group if
@@ -38,10 +40,12 @@ def test_error_stat(spark):
     ]
     results_to_compare = [];
     for result in results:
-        results_to_compare.append(result.asDict());
+        results_to_compare.append(result.asDict())
 
     assert len(expected_results) == len(results_to_compare)
 
     for expected_result in expected_results:
         assert expected_result in results_to_compare
 
+    assert analyzer.get_log_analyzer_stats(datetime(2017, 2, 15, 15, 12)) == \
+           "[spark-stat-analyzer] [OK] [2017-02-15 15:12:00] [2017-02-15 15:10:00] [ErrorStatsUpdater] [120]"

--- a/tests/fixtures/error_stat/2017/01/15/error_stat.json.log
+++ b/tests/fixtures/error_stat/2017/01/15/error_stat.json.log
@@ -1,11 +1,11 @@
-{"coverages": [{"region_id": "fr-foo"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.another_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 138461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 43, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "another_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "another_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@canaltp.fr"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
-{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-foo"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.another_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1384611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 43, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "another_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "another_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@canaltp.fr"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 1484611200, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
 

--- a/tests/fixtures/error_stat/2017/01/15/error_stat.json.log
+++ b/tests/fixtures/error_stat/2017/01/15/error_stat.json.log
@@ -1,0 +1,11 @@
+{"coverages": [{"region_id": "fr-foo"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.another_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 138461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 43, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "another_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "another_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@canaltp.fr"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+{"coverages": [{"region_id": "fr-idf"}], "api": "v1.some_api", "request_date": 148461120, "user_id": 42, "application_name": "my_app", "error": {"id": "some_error_id"}, "user_name": "foo@gmail.com"}
+

--- a/tests/token_stat_test.py
+++ b/tests/token_stat_test.py
@@ -5,7 +5,6 @@ import os
 
 pytestmark = pytest.mark.usefixtures("spark")
 
-
 def test_token_stat(spark):
     path = os.getcwd() + "/tests/fixtures/token_stat"
     start_date = date(2017, 1, 15)


### PR DESCRIPTION
This PR adds the error_stats analyzer, I omitted the nb_without_journey column as it is not used anywhere (in stat_compiled.error_stats table)

To test, run: `path-to-spark-submit --conf spark.ui.showConsoleProgress=true --master='local[*]' manage.py -a error_stat -i ~/workspace/spark-stat-analyzer/export -s 2017-01-17 -e 2017-01-17`