### PR TITLE
Fix coverage_journeys_transfers rdd mode when we get data.

### DIFF
--- a/analyzers/analyzer.py
+++ b/analyzers/analyzer.py
@@ -33,12 +33,12 @@ class Analyzer(object):
 
     def collect_data(self, dataframe):
         if dataframe.count():
-            coverage_modes = dataframe.flatMap(
+            data = dataframe.flatMap(
                 self.get_tuples_from_stat_dict
             ).reduceByKey(
                 lambda a, b: a + b
             ).collect()
-            return [tuple(list(key_tuple) + [nb]) for (key_tuple, nb) in coverage_modes]
+            return [tuple(list(key_tuple) + [nb]) for (key_tuple, nb) in data]
         else:
             return []
 

--- a/analyzers/coverage_journeys.py
+++ b/analyzers/coverage_journeys.py
@@ -30,8 +30,8 @@ class AnalyzeCoverageJourneys(Analyzer):
             )
 
     def launch(self):
-        journeys_stats = self.get_data(rdd_mode=True)
-        self.truncate_and_insert(journeys_stats)
+        coverage_journeys = self.get_data(rdd_mode=True)
+        self.truncate_and_insert(coverage_journeys)
 
     @property
     def analyzer_name(self):

--- a/analyzers/coverage_journeys_requests_params.py
+++ b/analyzers/coverage_journeys_requests_params.py
@@ -32,8 +32,8 @@ class AnalyzeCoverageJourneysRequestsParams(Analyzer):
             )
 
     def launch(self):
-        wheelchair_stats = self.get_data(rdd_mode=True)
-        self.truncate_and_insert(wheelchair_stats)
+        coverage_journeys_requests_params = self.get_data(rdd_mode=True)
+        self.truncate_and_insert(coverage_journeys_requests_params)
 
     @property
     def analyzer_name(self):

--- a/analyzers/coverage_journeys_transfers.py
+++ b/analyzers/coverage_journeys_transfers.py
@@ -41,8 +41,8 @@ class AnalyzeCoverageJourneysTransfers(Analyzer):
                                  end_date=self.end_date)
 
     def launch(self):
-        coverage_modes = self.get_data()
-        self.truncate_and_insert(coverage_modes)
+        coverage_journeys_transfers = self.get_data(rdd_mode=True)
+        self.truncate_and_insert(coverage_journeys_transfers)
 
     @property
     def analyzer_name(self):

--- a/analyzers/coverage_networks.py
+++ b/analyzers/coverage_networks.py
@@ -49,8 +49,8 @@ class AnalyzeCoverageNetworks(Analyzer):
                                  , data, self.start_date, self.end_date)
 
     def launch(self):
-        coverage_stop_areas = self.get_data(rdd_mode=True)
-        self.truncate_and_insert(coverage_stop_areas)
+        coverage_networks = self.get_data(rdd_mode=True)
+        self.truncate_and_insert(coverage_networks)
 
     @property
     def analyzer_name(self):

--- a/analyzers/requests_calls.py
+++ b/analyzers/requests_calls.py
@@ -49,8 +49,8 @@ class AnalyzeRequest(Analyzer):
                                  end_date=self.end_date)
 
     def launch(self):
-        token_stats = self.get_data()
-        self.truncate_and_insert(token_stats)
+        requests_calls = self.get_data()
+        self.truncate_and_insert(requests_calls)
 
     @property
     def analyzer_name(self):

--- a/analyzers/users_sql.py
+++ b/analyzers/users_sql.py
@@ -43,8 +43,8 @@ class AnalyseUsersSql(Analyzer):
                                  delete=False)
 
     def launch(self):
-        token_stats = self.get_data()
-        self.insert_or_update(token_stats)
+        users = self.get_data()
+        self.insert_or_update(users)
 
     @property
     def analyzer_name(self):


### PR DESCRIPTION
# Description

This PR fix this error:

```
17/03/06 11:06:32 INFO DAGScheduler: ResultStage 2 (count at NativeMethodAccessorImpl.java:0) finished in 0.093 s
17/03/06 11:06:32 INFO DAGScheduler: Job 1 finished: count at NativeMethodAccessorImpl.java:0, took 68.194476 s
17/03/06 11:06:32 INFO CodeGenerator: Code generated in 15.170796 ms
Traceback (most recent call last):
  File "/srv/stats/spark-stat-analyzer/manage.py", line 29, in <module>
    analyzer.launch()
  File "/srv/stats/spark-stat-analyzer/analyzers/coverage_journeys_transfers.py", line 44, in launch
    coverage_modes = self.get_data()
  File "/srv/stats/spark-stat-analyzer/analyzers/analyzer.py", line 48, in get_data
    return self.collect_data(df)
  File "/srv/stats/spark-stat-analyzer/analyzers/analyzer.py", line 36, in collect_data
    coverage_modes = dataframe.flatMap(
  File "/opt/spark/python/lib/pyspark.zip/pyspark/sql/dataframe.py", line 964, in __getattr__
AttributeError: 'DataFrame' object has no attribute 'flatMap'
17/03/06 11:06:32 INFO SparkContext: Invoking stop() from shutdown hook

```