### PR TITLE
coverage_journeys table updated to get tad information.

### DIFF
--- a/analyzers/analyzer.py
+++ b/analyzers/analyzer.py
@@ -1,11 +1,11 @@
 from abc import abstractmethod, ABCMeta
+from operator import add
 from glob import glob
 from datetime import timedelta, datetime
 import math
 from includes.logger import get_basic_logger
 import json
 import os
-
 
 class Analyzer(object):
     __metaclass__ = ABCMeta
@@ -31,11 +31,15 @@ class Analyzer(object):
     def get_tuples_from_stat_dict(stat_dict):
         pass
 
+    @staticmethod
+    def get_logic_to_reduce_by_key(a, b):
+        return add(a, b)
+
     def collect_data(self, dataframe):
         data = dataframe.flatMap(
             self.get_tuples_from_stat_dict
         ).reduceByKey(
-            lambda a, b: a + b
+            self.get_logic_to_reduce_by_key
         ).collect()
         return [tuple(list(key_tuple) + [nb]) for (key_tuple, nb) in data]
 

--- a/analyzers/coverage_journeys.py
+++ b/analyzers/coverage_journeys.py
@@ -1,3 +1,4 @@
+from operator import add
 from analyzers.analyzer import Analyzer
 from analyzers.stat_utils import region_id, is_internal_call, request_date
 
@@ -5,7 +6,15 @@ from analyzers.stat_utils import region_id, is_internal_call, request_date
 class AnalyzeCoverageJourneys(Analyzer):
     @staticmethod
     def get_tuples_from_stat_dict(stat_dict):
+        nb_journey_with_odt = 0
         journeys = stat_dict.get('journeys', [])
+
+        for journey in journeys:
+            if any(section['type'] == 'on_demand_transport' for section in journey.get('sections', [])):
+                nb_journey_with_odt += 1
+                break
+
+
         if not len(journeys):
             return []
         return [
@@ -15,14 +24,27 @@ class AnalyzeCoverageJourneys(Analyzer):
                     region_id(stat_dict),
                     is_internal_call(stat_dict)
                 ),
-                len(journeys)
+                (
+                    len(journeys),
+                    nb_journey_with_odt
+                )
             )
         ]
+
+    @staticmethod
+    def get_logic_to_reduce_by_key(a, b):
+        return (add(a[0], b[0]), add(a[1], b[1]))
+
+    def convert_data(self, data):
+        result = data
+        data[:] = [(element[0],element[1],element[2]) + element[3] for element in data]
+
+        return result
 
     def truncate_and_insert(self, data):
         self.database.insert(
             "coverage_journeys",
-            ("request_date", "region_id", "is_internal_call", "nb"),
+            ("request_date", "region_id", "is_internal_call", "nb", "nb_with_odt"),
             data,
             self.start_date,
             self.end_date
@@ -30,7 +52,7 @@ class AnalyzeCoverageJourneys(Analyzer):
 
     def launch(self):
         coverage_journeys = self.get_data(rdd_mode=True)
-        self.truncate_and_insert(coverage_journeys)
+        self.truncate_and_insert(self.convert_data(coverage_journeys))
 
     @property
     def analyzer_name(self):

--- a/migrations/alembic/versions/2dc7abaa8047_add_nb_with_tad_column_from_coverage_.py
+++ b/migrations/alembic/versions/2dc7abaa8047_add_nb_with_tad_column_from_coverage_.py
@@ -1,0 +1,23 @@
+"""Add nb_with_odt column from coverage_journeys
+
+Revision ID: 2dc7abaa8047
+Revises: b4902311ea96
+Create Date: 2017-03-14 13:02:53.031755
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2dc7abaa8047'
+down_revision = 'b4902311ea96'
+
+from alembic import op
+import sqlalchemy as sa
+import config
+
+schema = config.db['schema']
+
+def upgrade():
+    op.add_column('coverage_journeys', sa.Column('nb_with_odt', sa.BigInteger(), nullable=True), schema=schema)
+
+def downgrade():
+    op.drop_column('coverage_journeys', 'nb_with_odt', schema=schema)

--- a/tests/coverage_journeys_test.py
+++ b/tests/coverage_journeys_test.py
@@ -10,8 +10,8 @@ def test_count_journeys(spark):
     start_date = date(2017, 1, 20)
     end_date = date(2017, 1, 20)
     expected_results = [
-        (datetime.utcfromtimestamp(1484993662).date(), u'fr-foo', 0, 9),
-        (datetime.utcfromtimestamp(1484993662).date(), u'fr-bar', 0, 8)
+        (datetime.utcfromtimestamp(1484993662).date(), u'fr-foo', 0, (9, 4)),
+        (datetime.utcfromtimestamp(1484993662).date(), u'fr-bar', 0, (8, 1))
     ]
 
     analyzer = AnalyzeCoverageJourneys(storage_path=path,

--- a/tests/fixtures/coverage_journeys/2017/01/20/journeys.json.log
+++ b/tests/fixtures/coverage_journeys/2017/01/20/journeys.json.log
@@ -1,11 +1,11 @@
 {"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":[]}
 {"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo"}
-{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1"]}
-{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
-{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":["journeys_1", "journeys_2"]}
+{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"on_demand_transport"},{"type":"on_demand_transport"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"on_demand_transport"},{"type":"transfer"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"on_demand_transport"},{"type":"transfer"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-foo"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"on_demand_transport"},{"type":"transfer"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"waiting"},{"type":"transfer"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"waiting"},{"type":"transfer"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"waiting"},{"type":"transfer"}]}, {"sections":[{"type":"public_transport"},{"type":"transfer"}]}]}
+{"coverages":[{"region_id":"fr-bar"}],"request_date":1485011200,"user_name":"foo","journeys":[{"sections":[{"type":"waiting"},{"type":"transfer"}]}, {"sections":[{"type":"on_demand_transport"},{"type":"transfer"}]}]}

--- a/tests/integrations/coverage_journeys_test.py
+++ b/tests/integrations/coverage_journeys_test.py
@@ -8,10 +8,10 @@ class TestAnalyzeCoverageJourneys(Mechanism):
     def test_coverage_journeys(self):
         self.launch(analyzer='coverage_journeys', start_date='2017-01-20', end_date='2017-01-20')
         result = self.get_data(table_name='coverage_journeys',
-                               columns=['request_date', 'region_id', 'is_internal_call', 'nb'])
+                               columns=['request_date', 'region_id', 'is_internal_call', 'nb', 'nb_with_odt'])
         expected_results = [
-            (datetime(2017, 1, 21, 0, 0), 'fr-foo', 0, 9),
-            (datetime(2017, 1, 21, 0, 0), 'fr-bar', 0, 8)
+            (datetime(2017, 1, 21, 0, 0), 'fr-foo', 0, 9, 4),
+            (datetime(2017, 1, 21, 0, 0), 'fr-bar', 0, 8, 1)
         ]
 
         assert same_list_tuple(result, expected_results)


### PR DESCRIPTION
# Description 

This PR update `coverage_journeys` table to get `nb_with_tad` information per journeys.

SQL request should be:
```
SELECT 
	SUM(cj.nb_with_odt) AS with_odt,
	(SUM(cj.nb) - SUM(cj.nb_with_odt))  AS without_odt
FROM
	stat_compiled.coverage_journeys cj
WHERE
	cj.request_date >= :start_date
	AND cj.request_date < :end_date
	AND cj.region_id = :coverage
	AND cj.is_internal_call = 0
GROUP BY
	cj.region_id
```