### PR TITLE
Make tests work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gettyimages/spark:2.1.0-hadoop-2.7
+FROM gettyimages/spark:2.4.1-hadoop-3.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -23,7 +23,7 @@ RUN set -xe && \
 
 RUN cp config.py.docker config.py && rm config.py.dist && rm config.py.docker
 RUN zip -r spark-stat-analyzer.zip analyzers includes
-RUN cp /usr/spark-2.1.0/conf/log4j.properties.template /usr/spark-2.1.0/conf/log4j.properties
-RUN sed -i 's/INFO, console/WARN, console/g' /usr/spark-2.1.0/conf/log4j.properties
+RUN cp /usr/spark-2.4.1/conf/log4j.properties.template /usr/spark-2.4.1/conf/log4j.properties
+RUN sed -i 's/INFO, console/WARN, console/g' /usr/spark-2.4.1/conf/log4j.properties
 
 CMD ["bash"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM gettyimages/spark:2.1.0-hadoop-2.7
+FROM gettyimages/spark:2.4.1-hadoop-3.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -26,7 +26,7 @@ COPY . /srv/spark-stat-analyzer
 
 RUN cp config.py.docker config.py && rm config.py.dist && rm config.py.docker
 RUN zip -r spark-stat-analyzer.zip analyzers includes tests models.py
-RUN cp /usr/spark-2.1.0/conf/log4j.properties.template /usr/spark-2.1.0/conf/log4j.properties
-RUN sed -i 's/INFO, console/ERROR, console/g' /usr/spark-2.1.0/conf/log4j.properties
+RUN cp /usr/spark-2.4.1/conf/log4j.properties.template /usr/spark-2.4.1/conf/log4j.properties
+RUN sed -i 's/INFO, console/ERROR, console/g' /usr/spark-2.4.1/conf/log4j.properties
 
 CMD ["./run_test.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2-binary
-alembic==0.9.1
-SQLAlchemy==1.0.4
+alembic==1.0.10
+SQLAlchemy==1.3.4

--- a/tests/integrations/mechanism.py
+++ b/tests/integrations/mechanism.py
@@ -18,7 +18,7 @@ class Mechanism(object):
     def call(cls, cmd):
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = p.communicate(timeout=15*60)
-        if stderr:
+        if p.returncode != 0:
             raise Exception(str(stderr))
 
     @classmethod


### PR DESCRIPTION
docker image `gettyimages/spark:2.4.1-hadoop-2.7` seems bad
I updated the image and made the tests work

```
docker-compose -f docker-composer.test.yml build
docker-compose -f docker-composer.test.yml run spark-stat-analyser
```
