### PR TITLE
remove warnings during tests

### DIFF
--- a/includes/utils.py
+++ b/includes/utils.py
@@ -47,5 +47,12 @@ def date_format(value):
 
 def sub_iterable(iterable, size, format=tuple):
     it = iter(iterable)
-    while True:
-        yield format(chain((next(it),), islice(it, size - 1)))
+    # tests have this warning: "PendingDeprecationWarning: generator 'sub_iterable' raised StopIteration"
+    # => ignore StopIteration here since we know it will happen by design
+    # for more info about handling deprecation of "StopIteration" see
+    # https://www.python.org/dev/peps/pep-0479/#making-return-triggered-stopiterations-obvious
+    try:
+        while True:
+            yield format(chain((next(it),), islice(it, size - 1)))
+    except StopIteration:
+        pass

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=legacy


### PR DESCRIPTION
Warnings were

```
/usr/local/lib/python3.5/dist-packages/_pytest/junitxml.py:436
  /usr/local/lib/python3.5/dist-packages/_pytest/junitxml.py:436: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)

tests/utils_test.py::test_sub_iterable_empty
  /srv/spark-stat-analyzer/tests/utils_test.py:62: PendingDeprecationWarning: generator 'sub_iterable' raised StopIteration
    assert len([v for v in values]) == 0

tests/utils_test.py::test_sub_iterable_format_tuple
  /srv/spark-stat-analyzer/tests/utils_test.py:69: PendingDeprecationWarning: generator 'sub_iterable' raised StopIteration
    assert [v for v in result] == expected_results

tests/utils_test.py::test_sub_iterable_format_list
  /srv/spark-stat-analyzer/tests/utils_test.py:73: PendingDeprecationWarning: generator 'sub_iterable' raised StopIteration
    result = [v for v in sub_iterable([1, 2, 3, 4, 5], 2, list)]

tests/utils_test.py::test_sub_iterable_format_string
  /srv/spark-stat-analyzer/tests/utils_test.py:83: PendingDeprecationWarning: generator 'sub_iterable' raised StopIteration
    result = [v for v in sub_iterable("iterable", 2, list)]

tests/integrations/users_test.py::TestAnalyzeUsers::test_users_no_update_on_null_date
  /srv/spark-stat-analyzer/includes/database.py:82: PendingDeprecationWarning: generator 'sub_iterable' raised StopIteration
    for records in sub_iterable(data, self.insert_count):
```

with this PR, thay have disappeared :wink: 